### PR TITLE
Tweak label, input element attributes and update README

### DIFF
--- a/SFD/README.md
+++ b/SFD/README.md
@@ -1,26 +1,23 @@
 
 # Seattle Fire Department Incident Card
 
-Work in progress to create a Winlink form to automate the process described
-in this page from the Seattle ACS Action Plan for a recent SFD Windshield
+Work in progress to create a Winlink form to automate the process described in this page from the Seattle ACS Action Plan for a recent SFD Windshield
+
 Exercise:
 
-<img src="images/SFD_card_example.jpg" width=800/>
-
+![Incident Card example from a past SFD Windshield Exercise](images/SFD_card_example.jpg)
 
 ## Another example incident card
 
 This image has better resolution, note the faint writing:
 
-<img src="images/IMG_1217.jpeg" width=500/>
+![Appendix 3 - Incident Card (example)](images/IMG_1217.jpeg)
 
 ## Draft of 2026-05-04
 
 ### Try out the web browser version
 
-You can type into [this live sample version](https://faculty.washington.edu/rjl/misc/SFD_incident_card-form.html).  The Submit, and Load buttons do not do anything,
-but the Save button should save a file to your local computer (which could
-later be transferred to Winlink).
+You can type into [this live sample version](https://faculty.washington.edu/rjl/misc/SFD_incident_card-form.html).  The Submit, and Load buttons do not do anything, but the Save button should save a file to your local computer (which could later be transferred to Winlink).
 
 ### Install in Winlink
 
@@ -30,37 +27,28 @@ To try it in Winlink, copy these files into your Winlink Express `Global Folders
 - SFD_incident_card-template.txt
 
 Then compose a new message, selecting the template under `General Templates`.
-This should open a browser window that looks the same as the sample web version
-above, but if opened from within Winlink the "Submit" button should work to
-translate the html form information into a Winlink message, which you can
-then "Post to Outbox".
 
-The "Save Data" button should work too and eventually so will
-the "Load Data" button, but this is not yet implemented.
+This should open a browser window that looks the same as the sample web version above, but if opened from within Winlink the "Submit" button should work to translate the html form information into a Winlink message, which you can then "Post to Outbox".
 
-Also not yet implemented is a Viewer version that allows an incoming Winlink
-message based on this form to be nicely displayed in a browser.  But a recipient
-will see the email message text, as illustrated below.
+The "Save Data" button should work too.
 
+Also not yet implemented is a Viewer version that allows an incoming Winlink message based on this form to be nicely displayed in a browser.  But a recipient will see the email message text, as illustrated below.
 
+### Form input
 
-### Form input:
+![Form input example](images/draft2_form.jpg)
 
-<img src="images/draft2_form.jpg" width=600/>
+### Resulting Winlink message
 
-### Resulting Winlink message:
-
-<img src="images/SFDversion3.png" width=600/>
-
+![Resulting Winlink Message example](images/SFDversion3.png)
 [cropped]
 
-
-### What gets saved:
+### What gets saved
 
 If you click "Save Data", a text file with a name like
 `SFD-card-saved-data-2026-05-04-21_23.txt` will be saved, containing
 
-```
+```json
 {
   "MyCallsign": "STATION 38 / KJ7WLT",
   "ToCallsign": "W7ACS",
@@ -89,13 +77,15 @@ If you click "Save Data", a text file with a name like
 }
 ```
 
-## Notes:
+## Notes
 
 - This is a draft. I'm soliciting input.
 
-- The "Load Data" button doesn't work yet.
-
 - There's no Viewer form yet for converting an incoming Winlink message to a nice html version.
 
-- Many thanks to Jon K7RMZ for running a workshop and providing several examples at
-  https://github.com/nojronatron/wl-forms-training.  Some ideas also adapted from his [Bigfoot bib tracker form](https://github.com/nojronatron/Bigfoot-Bib-Report-WL-Form) and from some info on the Winlink pages, e.g. [create_template.pdf](https://winlink.org/sites/default/files/RMSE_FORMS/create_templates.pdf).
+- Many thanks to Jon K7RMZ for running a workshop and providing several examples at his [Winlink Forms Training Github Repo](https://github.com/nojronatron/wl-forms-training)
+
+Some ideas also adapted from:
+
+- K7RMZ's [Bigfoot bib tracker form](https://github.com/nojronatron/Bigfoot-Bib-Report-WL-Form)
+- Info on the Winlink pages [create_template.pdf](https://winlink.org/sites/default/files/RMSE_FORMS/create_templates.pdf)

--- a/SFD/SFD_incident_card-form.html
+++ b/SFD/SFD_incident_card-form.html
@@ -500,26 +500,26 @@
             <form
                 onsubmit="return confirmSubmit();"
                 method="post" id="myform" enctype="multipart/form-data" action="http://{FormServer}:{FormPort}">
-                <label class="formTitleHeader">Seattle Fire Department Incident Card</label>
+                <div class="formTitleHeader">Seattle Fire Department Incident Card</div>
 
                 <hr />
 
                 <div class="msgHeaderTitle">Message Header (for Winlink submission)</div>
 
                 <div class="input-container">
-                    <label for="tocall"><b>To</b> (Winlink address - callsign or email):</label>
+                    <label for="toCallsign"><b>To</b> (Winlink address - callsign or email):</label>
                     <input type="text" name="tocall" id="toCallsign"
                         placeholder="" value=""/>
                 </div>
                 <div class="input-container">
-                    <label for="acsno"><b>ACS Message Number</b> (e.g. STN00-0001):</label>
+                    <label for="ACSno"><b>ACS Message Number</b> (e.g. STN00-0001):</label>
                     <input type="text" name="acsno" id="ACSno"
                         placeholder="" value=""/>
                 </div>
 
                 <div class="input-container">
                     <label for="Exer"><b>This is an exercise</b>:</label>
-                    <input type="checkbox" name="Exer" value=""
+                    <input type="checkbox" name="Exer" value="" id="Exer"
                      onclick="if(document.getElementById('IsExer').value =='')
                      {document.getElementById('IsExer').value = IsAnExerciseText}
                      else { document.getElementById('IsExer').value = '';}"/>
@@ -535,13 +535,13 @@
                     <label for="company">CO:</label>
                     <input type="text" name="company" id="company"
                         size="5" value=""/>
-                    <label for="time">TIME:</label>
+                    <label for="Time">TIME:</label>
                     <input type="text" name="time" id="Time"
                         size="5" value=""/>
                 </div>
                 <hr />
                 <div class="input-container">
-                    <label for="PlaceNameBldgType">PLACE NAME / BUILDING TYPE:</label>
+                    <label for="PNBT">PLACE NAME / BUILDING TYPE:</label>
                     <textarea rows="1" cols="40" name="PlaceNameBldgType" id="PNBT"
                         value=""></textarea>
                 </div>
@@ -556,8 +556,9 @@
                     <b>CONDITIONS:</b>
                 </div>
                 <div class="input-container">
-                    <label for="collapse-risk">Collapse --- &nbsp;&nbsp; risk:</label>
-                    <input type="checkbox" name="collapse-risk" value=''
+                    <span>Collapse --- </span>
+                    <label for="collapse-risk">risk:</label>
+                    <input type="checkbox" name="collapse-risk" value='' id="collapse-risk"
                         onclick="if(document.getElementById('IsCollapse_risk').value =='')
                         {document.getElementById('IsCollapse_risk').value = 'X'}
                         else { document.getElementById('IsCollapse_risk').value = '';}"/>
@@ -565,7 +566,7 @@
                         id="IsCollapse_risk" />
 
                     <label for="collapse-partial">&nbsp;&nbsp; partial:</label>
-                    <input type="checkbox" name="collapse-partial" value=''
+                    <input type="checkbox" name="collapse-partial" value='' id="collapse-partial"
                         onclick="if(document.getElementById('IsCollapse_partial').value =='')
                         {document.getElementById('IsCollapse_partial').value = 'X'}
                         else { document.getElementById('IsCollapse_partial').value = '';}"/>
@@ -573,7 +574,7 @@
                         id="IsCollapse_partial" />
 
                     <label for="collapse-full">&nbsp;&nbsp; full:</label>
-                    <input type="checkbox" name="collapse-full" value=''
+                    <input type="checkbox" name="collapse-full" value='' id="collapse-full"
                         onclick="if(document.getElementById('IsCollapse_full').value =='')
                         {document.getElementById('IsCollapse_full').value = 'X'}
                         else { document.getElementById('IsCollapse_full').value = '';}"/>
@@ -582,7 +583,7 @@
                 </div>
                 <div class="input-container">
                     <label for="fire">Fire:</label>
-                    <input type="checkbox" name="fire"  value=''
+                    <input type="checkbox" name="fire"  value='' id="fire"
                      onclick="if(document.getElementById('IsFire').value =='')
                      {document.getElementById('IsFire').value = 'X'}
                      else { document.getElementById('IsFire').value = '';}"/>
@@ -590,7 +591,7 @@
                 </div>
                 <div class="input-container">
                     <label for="fuel-gas-water">Fuel/Gas/Water:</label>
-                    <input type="checkbox" name="fuel-gas-water" value=''
+                    <input type="checkbox" name="fuel-gas-water" value='' id="fuel-gas-water"
                      onclick="if(document.getElementById('IsFGW').value =='')
                      {document.getElementById('IsFGW').value = 'X'}
                      else { document.getElementById('IsFGW').value = '';}"/>
@@ -598,7 +599,7 @@
                 </div>
                 <div class="input-container">
                     <label for="hazmat">HAZMAT:</label>
-                    <input type="checkbox" name="hazmat" value=''
+                    <input type="checkbox" name="hazmat" value='' id="hazmat"
                      onclick="if(document.getElementById('IsHazmat').value =='')
                      {document.getElementById('IsHazmat').value = 'X'}
                      else { document.getElementById('IsHazmat').value = '';}"/>
@@ -606,7 +607,7 @@
                 </div>
                 <div class="input-container">
                     <label for="landslide">Landslide:</label>
-                    <input type="checkbox" name="landslide" value=''
+                    <input type="checkbox" name="landslide" value='' id="landslide"
                      onclick="if(document.getElementById('IsLandslide').value =='')
                      {document.getElementById('IsLandslide').value = 'X'}
                      else { document.getElementById('IsLandslide').value = '';}"/>
@@ -614,7 +615,7 @@
                 </div>
                 <div class="input-container">
                     <label for="other">Other:</label>
-                    <input type="checkbox" name="other"  value=''
+                    <input type="checkbox" name="other"  value='' id="other"
                      onclick="if(document.getElementById('IsOther').value =='')
                      {document.getElementById('IsOther').value = 'X'}
                      else { document.getElementById('IsOther').value = '';}"/>
@@ -644,25 +645,25 @@
                            name="actions" id="actions"></textarea>
                 </div>
                 <div class="input-container">
-                    <label for="cardid"><b>SFD incident card number</b>:</label>
+                    <label for="CardB"><b>SFD incident card number</b>:</label>
                     <font size=+3><b style="position: relative; top: 0.15em;">B</b></font><input type="text" name="cardB"
                         id="CardB" size="2" maxlength="2" value=""/>
                     -<input type="text" name="cardid" id="CardID" size="3"
                         maxlength="3" value=""/>
                     &nbsp;<span>(replace Xs once assigned)</span>
-                    </div>
+                </div>
 
-                    <div class="input-container">
+                <div class="input-container">
 
                     <label for="pending"><b>STATUS:</b> &nbsp;&nbsp; Pending (empty box):</label>
-                    <input type="radio" name="status" value='Pending'
+                    <input type="radio" name="status" value='Pending' id="pending"
                     checked />
 
                     <label for="active">&nbsp;&nbsp; Active (one slash):</label>
-                    <input type="radio" name="status" value='Active' />
+                    <input type="radio" name="status" value='Active' id="active" />
 
                     <label for="closed">&nbsp;&nbsp; Closed (full X):</label>
-                    <input type="radio" name="status" value='Closed' />
+                    <input type="radio" name="status" value='Closed' id="closed" />
                 </div>
 
                 <br />
@@ -671,13 +672,13 @@
                 <div class="msgHeaderTitle">Message Footer</div>
 
                 <div class="input-container">
-                    <label for="update"><b>UPDATE:</b></label>
-                    <input type="checkbox" name="update" value=''
+                    <label for="update-existing"><b>UPDATE:</b></label>
+                    <input type="checkbox" name="update" value='' id="update-existing"
                      onclick="if(document.getElementById('IsUpdate').value =='')
                      {document.getElementById('IsUpdate').value = 'X'}
                      else { document.getElementById('IsUpdate').value = '';}"/>
                     <input type="hidden" name="IsUpdate" id="IsUpdate" />
-                    <label for="update">check if this is an update to existing card</label>
+                    <label for="update-existing">check if this is an update to existing card</label>
                 </div>
 
                 <br />
@@ -689,7 +690,7 @@
                 </div>
 
                 <div class="input-container">
-                    <label for="mycall"><b>SUBMITTED BY:</b></label>
+                    <label for="myCallsign"><b>SUBMITTED BY (fcc callsign):</b></label>
                     <input type="text" name="mycall" id="myCallsign" size="30"
                         placeholder="" value=""/>
                 </div>


### PR DESCRIPTION
- [x] Separate the "conditions" from "collapse risk" using span element (helps with next item)
- [x] Enable input element highlighting when user clicks its label, to simplify data entry
- [x] Change labels without partner input elements to div or span
- [x] Fix linting warnings in README
- [x] Minor copy edits and formatting tweaks to README
- [x] Test form in MS Edge browser
